### PR TITLE
ENH: add check for one-to-many relationships

### DIFF
--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -214,6 +214,38 @@ def has_dtypes(df, items):
             raise AssertionError("{} has the wrong dtype ({})".format(k, v))
     return df
 
+
+def one_to_many(df, unitcol, manycol):
+    """
+    Assert that a many-to-one relationship is preserved between two
+    columns. For example, a retail store will have have distinct
+    departments, each with several employees. If each employee may
+    only work in a single department, then the relationship of the
+    department to the employees is one to many.
+
+    Parameters
+    ==========
+    df : DataFrame
+    unitcol : str
+        The column that encapulates the groups in ``manycol``.
+    manycol : str
+        The column that must remain unique in the distict pairs
+        between ``manycol`` and ``unitcol``
+
+    Returns
+    =======
+    df : DataFrame
+
+    """
+    subset = df[[manycol, unitcol]].drop_duplicates()
+    for many in subset[manycol].unique():
+        if subset[subset[manycol] == many].shape[0] > 1:
+            msg = "{} in {} has multiple values for {}".format(many, manycol, unitcol)
+            raise AssertionError(msg)
+
+    return df
+
+
 __all__ = ['is_monotonic', 'is_shape', 'none_missing', 'unique_index', 'within_n_std',
            'within_range', 'within_set', 'has_dtypes',
            'verify', 'verify_all', 'verify_any']

--- a/engarde/decorators.py
+++ b/engarde/decorators.py
@@ -115,6 +115,21 @@ def has_dtypes(items):
         return wrapper
     return decorate
 
+
+def one_to_many(unitcol, manycol):
+    """ Tests that each value in ``manycol`` only is associated with
+    just a single value in ``unitcol``.
+    """
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            ck.one_to_many(results, unitcol, manycol)
+            return result
+        return wrapper
+    return decorate
+
+
 def verify(func, *args, **kwargs):
     """
     Assert that `func(df, *args, **kwargs)` is true.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -219,6 +219,24 @@ def test_has_dtypes():
     with pytest.raises(AssertionError):
         dc.has_dtypes(items={'A': bool})(_noop)(df)
 
+def test_one_to_many():
+    df = pd.DataFrame({
+        'parameter': ['Cu', 'Cu', 'Pb', 'Pb'],
+        'units': ['ug/L', 'ug/L', 'ug/L', 'ug/L'],
+        'res': [2.0, 4.0, 6.0, 8.0]
+    })
+    result = ck.one_to_many(df, 'units', 'parameter')
+    tm.assert_frame_equal(df, result)
+
+def test_one_to_many_raises():
+    df = pd.DataFrame({
+        'parameter': ['Cu', 'Cu', 'Pb', 'Pb'],
+        'units': ['ug/L', 'ug/L', 'ug/L', 'mg/L'],
+        'res': [2.0, 4.0, 6.0, 0.008]
+    })
+    with pytest.raises(AssertionError):
+        ck.one_to_many(df, 'units', 'parameter')
+
 def test_verify():
     f = lambda x, n: len(x) > n
     df = pd.DataFrame({'A': [1, 2, 3]})


### PR DESCRIPTION
Here's a check for confirming that a one-to-many relationship is preserved across two columns.

Namely, I already use something like that this confirm that all of the measurements of a pollutant are recorded with the same units.

For instance, with this dataframe:
```
  parameter    res units
0        Cu  1.000  ug/L
1        Cu  2.000  ug/L
2        Cu  3.000  ug/L
3        Cu  4.000  ug/L
4        Pb  5.000  ug/L
5        Pb  6.000  ug/L
6        Pb  7.000  ug/L
7        Pb  0.008  mg/L
```

`one_to_many(df, 'units', 'parameter')` would throw an error b/c Pb has measurements in both ug/L and mg/L