### PR TITLE
BUG: Wrap message in a tuple

### DIFF
--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -105,7 +105,7 @@ def is_shape(df, shape):
     except AssertionError as e:
         msg = ("Expected shape: {}\n"
                "\t\tActual shape:   {}".format(shape, df.shape))
-        e.args = msg
+        e.args = (msg,)
         raise
     return df
 


### PR DESCRIPTION
Closes https://github.com/TomAugspurger/engarde/issues/22

Old: 

```python
In [1]: df = pd.DataFrame(np.random.randn(4, 2))

In [2]: import engarde.checks as ck

In [3]: ck.is_shape(df, (4, 3))
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-3-620ce6caf545> in <module>()
----> 1 ck.is_shape(df, (4, 3))

/Users/tom.augspurger/Envs/py3/lib/python3.4/site-packages/engarde/checks.py in is_shape(df, shape)
    102         check = np.all(np.equal(df.shape, shape) | (np.equal(shape, [-1, -1]) |
    103                                                     np.equal(shape, [None, None])))
--> 104         assert check
    105     except AssertionError as e:
    106         msg = ("Expected shape: {}\n"

AssertionError: ('E', 'x', 'p', 'e', 'c', 't', 'e', 'd', ' ', 's', 'h', 'a', 'p', 'e', ':', ' ', '(', '4', ',', ' ', '3', ')', '\n', '\t', '\t', 'A', 'c', 't', 'u', 'a', 'l', ' ', 's', 'h', 'a', 'p', 'e', ':', ' ', ' ', ' ', '(', '4', ',', ' ', '2', ')')
```

New: 

```python
In [3]: ck.is_shape(df, (4, 3))
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-3-620ce6caf545> in <module>()
----> 1 ck.is_shape(df, (4, 3))

/Users/tom.augspurger/sandbox/engarde/engarde/checks.py in is_shape(df, shape)
    102         check = np.all(np.equal(df.shape, shape) | (np.equal(shape, [-1, -1]) |
    103                                                     np.equal(shape, [None, None])))
--> 104         assert check
    105     except AssertionError as e:
    106         msg = ("Expected shape: {}\n"

AssertionError: Expected shape: (4, 3)
                Actual shape:   (4, 2)
```

I'll think about testing later.

cc @ianozsvald

I can cut a release if you like. There's just been a couple new commits since the last one. Development has been slow lately unfortunately.