### PR TITLE
Update none_missing decorator

### DIFF
--- a/engarde/decorators.py
+++ b/engarde/decorators.py
@@ -5,13 +5,13 @@ from functools import wraps
 
 import engarde.checks as ck
 
-def none_missing():
+def none_missing(columns=None):
     """Asserts that no missing values (NaN) are found"""
     def decorate(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             result = func(*args, **kwargs)
-            ck.none_missing(result)
+            ck.none_missing(result, columns=None)
             return result
         return wrapper
     return decorate

--- a/engarde/decorators.py
+++ b/engarde/decorators.py
@@ -11,7 +11,7 @@ def none_missing(columns=None):
         @wraps(func)
         def wrapper(*args, **kwargs):
             result = func(*args, **kwargs)
-            ck.none_missing(result, columns=None)
+            ck.none_missing(result, columns=columns)
             return result
         return wrapper
     return decorate


### PR DESCRIPTION
Update ``none_missing`` decorator to allow limiting the columns that should be checked for having ``Nan``-like values.

This fixes #26 AFAICT.