### PR TITLE
BUG: function within_n_std fails if df has non-numeric columns

### DIFF
--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -182,15 +182,15 @@ def within_n_std(df, n=3):
     ==========
     df : DataFame
     n : int
-      number of standard devations from the mean
+      number of standard deviations from the mean
 
     Returns
     =======
-    df : DatFrame
+    df : DataFrame
     """
     means = df.mean()
     stds = df.std()
-    inliers = (np.abs(df - means) < n * stds)
+    inliers = (np.abs(df[means.index] - means) < n * stds)
     if not np.all(inliers):
         msg = generic.bad_locations(~inliers)
         raise AssertionError(msg)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -195,7 +195,7 @@ def test_within_range():
         dc.within_range(items)(_noop)(df)
 
 def test_within_n_std():
-    df = pd.DataFrame({'A': np.arange(10)})
+    df = pd.DataFrame({'A': np.arange(10), 'B': list('abcde')*2})
     tm.assert_frame_equal(df, ck.within_n_std(df))
     tm.assert_frame_equal(df, dc.within_n_std()(_noop)(df))
 


### PR DESCRIPTION
Ffunction ``within_n_std`` fails currently if df has any non-numeric columns. See supplied test.

Code update and test supplied.