### PR TITLE
Hotfix: np.ravel and get_duplicates() future warnings

### DIFF
--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -43,6 +43,7 @@ def none_missing(df, columns=None):
         raise
     return df
 
+
 def is_monotonic(df, items=None, increasing=None, strict=False):
     """
     Asserts that the DataFrame is monotonic.
@@ -83,6 +84,7 @@ def is_monotonic(df, items=None, increasing=None, strict=False):
         if not good:
             raise AssertionError
     return df
+
 
 def is_shape(df, shape):
     """
@@ -150,7 +152,7 @@ def unique_index(df):
     try:
         assert df.index.is_unique
     except AssertionError as e:
-        e.args = df.index.get_duplicates()
+        e.args = df.index[df.index.duplicated()].unique()
         raise
     return df
 
@@ -176,6 +178,7 @@ def within_set(df, items=None):
             raise AssertionError('Not in set', bad)
     return df
 
+
 def within_range(df, items=None):
     """
     Assert that a DataFrame is within a range.
@@ -196,6 +199,7 @@ def within_range(df, items=None):
             bad = (lower > df[k]) | (upper < df[k])
             raise AssertionError("Outside range", bad)
     return df
+
 
 def within_n_std(df, n=3):
     """
@@ -220,6 +224,7 @@ def within_n_std(df, n=3):
         raise AssertionError(msg)
     return df
 
+
 def has_dtypes(df, items):
     """
     Assert that a DataFrame has ``dtypes``
@@ -237,7 +242,7 @@ def has_dtypes(df, items):
     dtypes = df.dtypes
     for k, v in items.items():
         if not dtypes[k] == v:
-            raise AssertionError("{} has the wrong dtype. Should be ({}), is ({})".format(k, v,dtypes[k]))
+            raise AssertionError("{} has the wrong dtype. Should be ({}), is ({})".format(k, v, dtypes[k]))
     return df
 
 
@@ -298,4 +303,4 @@ def is_same_as(df, df_to_compare, **kwargs):
 __all__ = ['is_monotonic', 'is_same_as', 'is_shape', 'none_missing',
            'unique_index', 'within_n_std', 'within_range', 'within_set',
            'has_dtypes', 'verify', 'verify_all', 'verify_any',
-           'one_to_many','is_same_as',]
+           'one_to_many', 'is_same_as', ]

--- a/engarde/generic.py
+++ b/engarde/generic.py
@@ -37,6 +37,7 @@ def verify(df, check, *args, **kwargs):
         raise
     return df
 
+
 def verify_all(df, check, *args, **kwargs):
     """
     Verify that all the entries in ``check(df, *args, **kwargs)``
@@ -50,6 +51,7 @@ def verify_all(df, check, *args, **kwargs):
         e.args = (msg, df[~result])
         raise
     return df
+
 
 def verify_any(df, check, *args, **kwargs):
     """
@@ -69,12 +71,13 @@ def verify_any(df, check, *args, **kwargs):
 # Error reporting
 # ---------------
 
+
 def bad_locations(df):
     columns = df.columns
     all_locs = chain.from_iterable(zip(df.index, cycle([col])) for col in columns)
-    bad = pd.Series(list(all_locs))[np.asarray(df).ravel(1)]
+    bad = pd.Series(list(all_locs))[np.asarray(df).ravel(order='F')]
     msg = bad.values
     return msg
 
-__all__ = ['verify', 'verify_all', 'verify_any', 'bad_locations']
 
+__all__ = ['verify', 'verify_all', 'verify_any', 'bad_locations']


### PR DESCRIPTION
Updates for two future warnings:
1. Using integers to specify order for np.ravel was deprecated in NumPy version 1.12.0, since it was an unintended feature (see release notes https://docs.scipy.org/doc/numpy-1.12.0/release.html#id13). Resulting order is unchanged from this update.

2. df.index.get_duplicates() was deprecated in 0.23.0. Updated code is taken directly from the warning's recommendation: https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.Index.get_duplicates.html#pandas.Index.get_duplicates